### PR TITLE
FIX: pasar parametro a funcion con misma firma que en el modulo l10n_…

### DIFF
--- a/models/account_invoice.py
+++ b/models/account_invoice.py
@@ -160,7 +160,7 @@ class GlobalDiscount(models.Model):
             result[key] = value
         return result
 
-    def _dte_to_xml(self, dte):
-        xml = super(GlobalDiscount, self)._dte_to_xml(dte)
+    def _dte_to_xml(self, dte, tpo_dte="Documento"):
+        xml = super(GlobalDiscount, self)._dte_to_xml(dte, tpo_dte)
         xml = xml.replace('<drlines>','').replace('</drlines>','')
         return xml


### PR DESCRIPTION
…cl_dte

En el modulo l10n_cl_dte, la funcion _dte_to_xml tiene un parametro opcional  tpo_dte="Documento", pero al heredar en este modulo se ignora ese parametro, por lo que al llamar a la funcion con el parametro adicional, sale un error.

Se debe heredar la funcion correctamente con los parametros originales